### PR TITLE
Fix wrong error handling

### DIFF
--- a/check_iostat
+++ b/check_iostat
@@ -51,7 +51,7 @@ help () {
 
 # Ensuring we have the needed tools:
 { [ ! -f "$iostat" ] || [ ! -f "$bc" ] || [ ! -f "$jq" ]; } && \
-	( echo -e "ERROR: You must have iostat, bc and jq installed in order to run this plugin\n" && exit 3)
+	echo -e "ERROR: You must have iostat, bc and jq installed in order to run this plugin\n" && exit 3
 
 # Getting parameters:
 while getopts "d:w:c:h" OPT; do


### PR DESCRIPTION
If one of the required tools is not installed the script reports this
error but fails to terminate. This is because the round brackets around
the "body" of the "if condition" spawn a subshell which runs the echo
command and then exists with error code 3. However, this does not affect
the exit behaviour of the "main" shell which happily continues to run
the check and even exits with 0.

Remove the brackets so the exit command runs on the main shell.